### PR TITLE
Allowing different archive format types.

### DIFF
--- a/lib/Gitlab/Api/Repositories.php
+++ b/lib/Gitlab/Api/Repositories.php
@@ -337,16 +337,14 @@ class Repositories extends AbstractApi
     }
 
     /**
-     * File content is base64 encoded and placed in the "content" index of the returning array.
-     * You can then save the content with the tar.gz extension
-     *
      * @param int $project_id
      * @param array $params
+     * @param string $format Options: "tar.gz", "zip", "tar.bz2" and "tar"
      * @return mixed
      */
-    public function archive($project_id, $params = array())
+    public function archive($project_id, $params = array(), $format = 'tar.gz')
     {
-        return $this->get($this->getProjectPath($project_id, 'repository/archive'), $params);
+        return $this->get($this->getProjectPath($project_id, 'repository/archive.'.$format), $params);
     }
 
     /**


### PR DESCRIPTION
Correcting incorrect comment about "content" key in array too.